### PR TITLE
Update for Laravel 11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,6 +24,9 @@ jobs:
           - laravel: 10.*
             testbench: 8.*
             carbon: ^2.63
+          - laravel: 10.*
+            testbench: 9.*
+            carbon: ^2.63
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,11 +21,11 @@ jobs:
         laravel: [10.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
+          - laravel: 11.*
+            testbench: 9.*
             carbon: ^2.63
           - laravel: 10.*
-            testbench: 9.*
+            testbench: 8.*
             carbon: ^2.63
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.8",
         "larastan/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.8",
+        "orchestra/testbench": "^8.8|^9.0",
         "pestphp/pest": "^2.20",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^10.0",
+        "illuminate/contracts": "^10.0|^11.0",
         "filament/filament": "^3.0"
         },
     "require-dev": {


### PR DESCRIPTION
This PR updates the dependencies for Laravel 11 and contextually also the GH Action that runs the tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Updated the testing workflow to support Laravel version 11.*, Testbench version 9.*, and Carbon version ^2.63.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->