### PR TITLE
Update run-tests.yml with Laravel 11 support.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,13 +1,6 @@
 name: run-tests
 
-on:
-  push:
-    paths:
-      - '**.php'
-      - '.github/workflows/run-tests.yml'
-      - 'phpunit.xml.dist'
-      - 'composer.json'
-      - 'composer.lock'
+on: [push, pull_request]
 
 jobs:
   test:
@@ -18,15 +11,16 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.3, 8.2, 8.1]
-        laravel: [10.*]
+        laravel: [11.*, 10.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
-            carbon: ^2.63
           - laravel: 10.*
             testbench: 8.*
-            carbon: ^2.63
+        exclude:
+          - laravel: 11.*
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -48,7 +42,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
         "spatie/laravel-package-tools": "^1.14.0",
         "illuminate/contracts": "^10.0|^11.0",
         "filament/filament": "^3.0"
-        },
+    },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.8",
+        "nunomaduro/collision": "^7.8|^8.0",
         "larastan/larastan": "^2.0.1",
         "orchestra/testbench": "^8.8|^9.0",
         "pestphp/pest": "^2.20",


### PR DESCRIPTION
Fix the dependencies and workflows for L11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the automated test workflow to trigger on both `push` and `pull_request` events.
	- Enhanced compatibility testing with added support for Laravel 11.* and adjustments for PHP versions.
	- Removed the Carbon dependency installation step from the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->