### PR TITLE
feat: follow filament plugin standards

### DIFF
--- a/src/LocalLogins.php
+++ b/src/LocalLogins.php
@@ -29,6 +29,19 @@ class LocalLogins implements Plugin
         //
     }
 
+    public static function make(): static
+    {
+        return app(static::class);
+    }
+
+    public static function get(): static
+    {
+        /** @var static $plugin */
+        $plugin = filament(app(static::class)->getId());
+
+        return $plugin;
+    }
+
     public function isEnabled(string $panelId): bool
     {
         return (bool) config("filament-local-logins.panels.{$panelId}.enabled") && ! empty(config("filament-local-logins.panels.{$panelId}.emails"));


### PR DESCRIPTION
Uses the methods from the Filament plugin skeleton project: https://github.com/filamentphp/plugin-skeleton

This allows the ability to add plugin via:

```
\BetterFuturesStudio\FilamentLocalLogins\LocalLogins::make()
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced static methods for easier instantiation and retrieval of plugin instances, enhancing class utility and streamlining plugin management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->