### PR TITLE
Add Filament 3–5 compatibility for v1.5

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2.5.0
+        uses: dependabot/fetch-metadata@v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Fix PHP code style issues
         uses: aglipanci/laravel-pint-action@2.6

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -11,18 +11,18 @@ jobs:
   phpstan:
     name: phpstan
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.5'
           coverage: none
 
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@v4
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan --error-format=github

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,10 @@
 name: run-tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,28 +5,80 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        php: [8.3, 8.2, 8.1]
-        laravel: [11.*, 10.*]
-        stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 11.*
-            testbench: 9.*
-          - laravel: 10.*
-            testbench: 8.*
-        exclude:
-          - laravel: 11.*
+          - os: ubuntu-latest
             php: 8.1
+            laravel: 10.*
+            filament: ^3.0
+            testbench: ^8.0
+            phpunit: ^10.5.36
+            stability: prefer-lowest
+          - os: ubuntu-latest
+            php: 8.2
+            laravel: 11.*
+            filament: ^3.0
+            testbench: ^9.0
+            phpunit: ^11.5.50
+            stability: prefer-stable
+          - os: ubuntu-latest
+            php: 8.2
+            laravel: 12.*
+            filament: ^3.0
+            testbench: ^10.0
+            phpunit: ^11.5.50
+            stability: prefer-stable
+          - os: ubuntu-latest
+            php: 8.2
+            laravel: 11.*
+            filament: ^4.0
+            testbench: ^9.0
+            phpunit: ^11.5.50
+            stability: prefer-lowest
+          - os: ubuntu-latest
+            php: 8.3
+            laravel: 12.*
+            filament: ^4.0
+            testbench: ^10.0
+            phpunit: ^12.5.8
+            stability: prefer-stable
+          - os: ubuntu-latest
+            php: 8.2
+            laravel: 11.*
+            filament: ^5.0
+            testbench: ^9.0
+            phpunit: ^11.5.50
+            stability: prefer-lowest
+          - os: ubuntu-latest
+            php: 8.3
+            laravel: 12.*
+            filament: ^5.0
+            testbench: ^10.0
+            phpunit: ^12.5.8
+            stability: prefer-stable
+          - os: ubuntu-latest
+            php: 8.3
+            laravel: 13.*
+            filament: ^5.0
+            testbench: ^11.0
+            phpunit: ^12.5.8
+            stability: prefer-stable
+          - os: windows-latest
+            php: 8.5
+            laravel: 13.*
+            filament: ^5.0
+            testbench: ^11.0
+            phpunit: ^13.0
+            stability: prefer-stable
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+    name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }} / Filament ${{ matrix.filament }} / ${{ matrix.stability }} / ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -42,11 +94,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "filament/filament:${{ matrix.filament }}" --no-interaction --no-update
+          composer require --dev "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies
-        run: composer show -D
+        run: composer show --direct
 
       - name: Execute tests
-        run: vendor/bin/pest --ci
+        run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,65 +17,65 @@ jobs:
           - os: ubuntu-latest
             php: 8.1
             laravel: 10.*
-            filament: ^3.0
-            testbench: ^8.0
-            phpunit: ^10.5.36
+            filament: 3.*
+            testbench: 8.*
+            phpunit: 10.5.*
             stability: prefer-lowest
           - os: ubuntu-latest
             php: 8.2
             laravel: 11.*
-            filament: ^3.0
-            testbench: ^9.0
-            phpunit: ^11.5.50
+            filament: 3.*
+            testbench: 9.*
+            phpunit: 11.5.*
             stability: prefer-stable
           - os: ubuntu-latest
             php: 8.2
             laravel: 12.*
-            filament: ^3.0
-            testbench: ^10.0
-            phpunit: ^11.5.50
+            filament: 3.*
+            testbench: 10.*
+            phpunit: 11.5.*
             stability: prefer-stable
           - os: ubuntu-latest
             php: 8.2
             laravel: 11.*
-            filament: ^4.0
-            testbench: ^9.0
-            phpunit: ^11.5.50
-            stability: prefer-lowest
-          - os: ubuntu-latest
-            php: 8.3
-            laravel: 12.*
-            filament: ^4.0
-            testbench: ^10.0
-            phpunit: ^12.5.8
-            stability: prefer-stable
-          - os: ubuntu-latest
-            php: 8.2
-            laravel: 11.*
-            filament: ^5.0
-            testbench: ^9.0
-            phpunit: ^11.5.50
+            filament: 4.*
+            testbench: 9.*
+            phpunit: 11.5.*
             stability: prefer-lowest
           - os: ubuntu-latest
             php: 8.3
             laravel: 12.*
-            filament: ^5.0
-            testbench: ^10.0
-            phpunit: ^12.5.8
+            filament: 4.*
+            testbench: 10.*
+            phpunit: 12.5.*
+            stability: prefer-stable
+          - os: ubuntu-latest
+            php: 8.2
+            laravel: 11.*
+            filament: 5.*
+            testbench: 9.*
+            phpunit: 11.5.*
+            stability: prefer-lowest
+          - os: ubuntu-latest
+            php: 8.3
+            laravel: 12.*
+            filament: 5.*
+            testbench: 10.*
+            phpunit: 12.5.*
             stability: prefer-stable
           - os: ubuntu-latest
             php: 8.3
             laravel: 13.*
-            filament: ^5.0
-            testbench: ^11.0
-            phpunit: ^12.5.8
+            filament: 5.*
+            testbench: 11.*
+            phpunit: 12.5.*
             stability: prefer-stable
           - os: windows-latest
             php: 8.5
             laravel: 13.*
-            filament: ^5.0
-            testbench: ^11.0
-            phpunit: ^13.0
+            filament: 5.*
+            testbench: 11.*
+            phpunit: 13.*
             stability: prefer-stable
 
     name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }} / Filament ${{ matrix.filament }} / ${{ matrix.stability }} / ${{ matrix.os }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: main
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `filament-local-logins` will be documented in this file.
 
+## 1.4.0 - 2025-05-05
+
+Add Laravel 12 support.
+
 ## 1.3.0 - 2025-02-12
 
 Add `make()` method to match filament structure.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 
 This package allows you to log in locally using pre-set email addresses, making it easy to log into one or multiple development user accounts. It can be used in an admin panel or multiple panels.
 
-**NOTE:** You must have created the user accounts in order to use them with the login buttons, this package doesn't support the creation of user accounts.
+> [!IMPORTANT]
+> Only enable local logins in trusted local environments. The package never creates users: every configured email must already belong to a user who can access the panel.
 
 ## Output
 
@@ -15,10 +16,15 @@ This package allows you to log in locally using pre-set email addresses, making 
 
 ## Requirements
 
-This package requires the following:
+Version 1 supports Filament 3, 4, and 5 while preserving the original PHP 8.1 and Laravel 10 support where the framework permits it.
 
-- `PHP:^8.1`
-- `Filament:^3.0`
+| Filament | Livewire | Laravel | PHP |
+| --- | --- | --- | --- |
+| `^3.0` | `^3.0` | 10–12 | `^8.1` |
+| `^4.0` | `^3.5` | 11–12 | `^8.2` |
+| `^5.0` | `^4.1` | 11–13 | `^8.2` |
+
+Composer will select the compatible versions for your application. Individual Laravel and Filament releases may require a newer PHP patch or minor version within these ranges.
 
 ## Installation
 
@@ -87,7 +93,21 @@ In your .env file, add the following:
 ADMIN_PANEL_LOCAL_LOGIN_EMAILS="free-user@example.com,paid-user@example.com" # Provide a comma-separated list of emails that can log in locally
 ```
 
-If you wish to customize the default login page, you can modify the `'login_page' => LoginPage::class,` line to point to your desired class. After changing this, you will need to use the `HasLocalLogins` trait in your custom login page class.
+If you wish to customize the default login page, change the `'login_page' => LoginPage::class,` line to point to your class and use the `HasLocalLogins` trait. Filament moved its login page namespace in version 4, so use the matching base class.
+
+For Filament 4 and 5:
+
+```php
+use BetterFuturesStudio\FilamentLocalLogins\Concerns\HasLocalLogins;
+use Filament\Auth\Pages\Login;
+
+class YourCustomLoginPage extends Login
+{
+    use HasLocalLogins;
+}
+```
+
+For Filament 3:
 
 ```php
 use BetterFuturesStudio\FilamentLocalLogins\Concerns\HasLocalLogins;
@@ -103,9 +123,11 @@ In your Filament panel provider, typically `AdminPanelProvider`, you need to reg
 
 ```php
 use BetterFuturesStudio\FilamentLocalLogins\LocalLogins;
-...
+
 $panel->plugin(new LocalLogins());
 ```
+
+Login requests are accepted only for the email addresses configured for the current panel. The selected user must also pass Filament's `canAccessPanel()` check.
 
 ## Testing
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "better-futures-studio/filament-local-logins",
-    "description": "This is my package filament-local-logins",
+    "description": "Quickly sign in to configured Filament accounts in local environments.",
     "keywords": [
         "better-futures-studio",
         "laravel",
@@ -17,24 +17,24 @@
     ],
     "require": {
         "php": "^8.1",
-        "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
-        "filament/filament": "^3.0"
+        "filament/filament": "^3.0|^4.0|^5.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+        "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
+        "larastan/larastan": "^2.9|^3.0",
         "nunomaduro/collision": "^7.8|^8.0",
-        "larastan/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.8|^9.0",
-        "pestphp/pest": "^2.20",
-        "pestphp/pest-plugin-arch": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0",
-        "spatie/laravel-ray": "^1.26"
+        "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+        "phpstan/phpstan-phpunit": "^1.0|^2.0",
+        "phpunit/phpunit": "^10.5.36|^11.5.50|^12.5.8|^13.0"
     },
     "autoload": {
+        "files": [
+            "src/compatibility.php"
+        ],
         "psr-4": {
             "BetterFuturesStudio\\FilamentLocalLogins\\": "src/",
             "BetterFuturesStudio\\FilamentLocalLogins\\Database\\Factories\\": "database/factories/"
@@ -60,14 +60,13 @@
             "@php vendor/bin/testbench serve"
         ],
         "analyse": "vendor/bin/phpstan analyse",
-        "test": "vendor/bin/pest",
-        "test-coverage": "vendor/bin/pest --coverage",
+        "test": "vendor/bin/phpunit",
+        "test-coverage": "vendor/bin/phpunit --coverage-text",
         "format": "vendor/bin/pint"
     },
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "pestphp/pest-plugin": true,
             "phpstan/extension-installer": true
         }
     },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,9 +5,6 @@ parameters:
     level: 5
     paths:
         - src
-        - config
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
-

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,13 +20,6 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>

--- a/resources/views/login-buttons.blade.php
+++ b/resources/views/login-buttons.blade.php
@@ -2,7 +2,9 @@
     @foreach ($this->localLoginEmails() as $email)
         <x-filament::button
             class="mb-2 w-full"
-            wire:click="loginUser('{{ $email }}')"
+            wire:click="loginUser({{ Illuminate\Support\Js::from($email) }})"
+            wire:loading.attr="disabled"
+            wire:target="loginUser"
         >
             Login as {{ $email }}
         </x-filament::button>

--- a/src/Concerns/HasLocalLogins.php
+++ b/src/Concerns/HasLocalLogins.php
@@ -4,11 +4,11 @@ namespace BetterFuturesStudio\FilamentLocalLogins\Concerns;
 
 use BetterFuturesStudio\FilamentLocalLogins\LocalLogins;
 use Filament\Facades\Filament;
-use Filament\Http\Responses\Auth\Contracts\LoginResponse;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Panel;
 use Illuminate\Auth\EloquentUserProvider;
 use Illuminate\Auth\SessionGuard;
+use Illuminate\Contracts\Support\Responsable;
 
 trait HasLocalLogins
 {
@@ -23,20 +23,18 @@ trait HasLocalLogins
             return [];
         }
 
-        $emails = config("filament-local-logins.panels.{$panel->getId()}.emails", []);
+        /** @var LocalLogins $plugin */
+        $plugin = $panel->getPlugin(LocalLogins::class);
 
-        if (! is_array($emails)) {
-            return [];
-        }
-
-        return $emails;
+        return $plugin->getEmails($panel->getId());
     }
 
-    public function loginUser(string $email): LoginResponse
+    public function loginUser(string $email): Responsable
     {
         $panel = Filament::getCurrentPanel();
 
         abort_unless($this->allowsLocalLogin($panel), 403, 'Local login is not allowed for this panel.');
+        abort_unless(in_array($email, $this->localLoginEmails(), true), 403, 'This account is not configured for local login.');
 
         throw_unless($panel instanceof Panel, 'The panel must be an instance of '.Panel::class);
 
@@ -70,12 +68,16 @@ trait HasLocalLogins
 
         session()->regenerate();
 
-        return app(LoginResponse::class);
+        $response = app($this->getLoginResponseContract());
+
+        throw_unless($response instanceof Responsable, 'The login response must implement '.Responsable::class);
+
+        return $response;
     }
 
     protected function allowsLocalLogin(?Panel $panel): bool
     {
-        if (empty($panel)) {
+        if (! $panel?->hasPlugin(LocalLogins::class)) {
             return false;
         }
 
@@ -86,5 +88,16 @@ trait HasLocalLogins
         }
 
         return $plugin->isEnabled($panel->getId());
+    }
+
+    protected function getLoginResponseContract(): string
+    {
+        $modernContract = 'Filament\\Auth\\Http\\Responses\\Contracts\\LoginResponse';
+
+        if (interface_exists($modernContract)) {
+            return $modernContract;
+        }
+
+        return 'Filament\\Http\\Responses\\Auth\\Contracts\\LoginResponse';
     }
 }

--- a/src/Filament/Pages/Auth/LoginPage.php
+++ b/src/Filament/Pages/Auth/LoginPage.php
@@ -3,9 +3,8 @@
 namespace BetterFuturesStudio\FilamentLocalLogins\Filament\Pages\Auth;
 
 use BetterFuturesStudio\FilamentLocalLogins\Concerns\HasLocalLogins;
-use Filament\Pages\Auth\Login;
 
-class LoginPage extends Login
+class LoginPage extends BaseLoginPage
 {
     use HasLocalLogins;
 }

--- a/src/LocalLogins.php
+++ b/src/LocalLogins.php
@@ -5,6 +5,8 @@ namespace BetterFuturesStudio\FilamentLocalLogins;
 use BetterFuturesStudio\FilamentLocalLogins\Filament\Pages\Auth\LoginPage;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
+use Filament\View\PanelsRenderHook;
+use Illuminate\Contracts\View\Factory as ViewFactory;
 
 class LocalLogins implements Plugin
 {
@@ -21,7 +23,10 @@ class LocalLogins implements Plugin
 
         $panel
             ->login(config("filament-local-logins.panels.{$panel->getId()}.login_page", LoginPage::class))
-            ->renderHook('panels::auth.login.form.before', fn () => view('filament-local-logins::login-buttons'));
+            ->renderHook(
+                PanelsRenderHook::AUTH_LOGIN_FORM_BEFORE,
+                fn () => app(ViewFactory::class)->make('filament-local-logins::login-buttons'),
+            );
     }
 
     public function boot(Panel $panel): void
@@ -44,6 +49,36 @@ class LocalLogins implements Plugin
 
     public function isEnabled(string $panelId): bool
     {
-        return (bool) config("filament-local-logins.panels.{$panelId}.enabled") && ! empty(config("filament-local-logins.panels.{$panelId}.emails"));
+        return (bool) config("filament-local-logins.panels.{$panelId}.enabled") && ($this->getEmails($panelId) !== []);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getEmails(string $panelId): array
+    {
+        $configuredEmails = config("filament-local-logins.panels.{$panelId}.emails", []);
+
+        if (! is_array($configuredEmails)) {
+            return [];
+        }
+
+        $emails = [];
+
+        foreach ($configuredEmails as $configuredEmail) {
+            if (! is_string($configuredEmail)) {
+                continue;
+            }
+
+            $email = trim($configuredEmail);
+
+            if (($email === '') || in_array($email, $emails, true)) {
+                continue;
+            }
+
+            $emails[] = $email;
+        }
+
+        return $emails;
     }
 }

--- a/src/compatibility.php
+++ b/src/compatibility.php
@@ -1,0 +1,24 @@
+<?php
+
+use BetterFuturesStudio\FilamentLocalLogins\Filament\Pages\Auth\BaseLoginPage;
+
+$filamentLoginPages = [
+    'Filament\\Auth\\Pages\\Login',
+    'Filament\\Pages\\Auth\\Login',
+];
+
+foreach ($filamentLoginPages as $filamentLoginPage) {
+    if (! class_exists($filamentLoginPage)) {
+        continue;
+    }
+
+    if (! class_exists(BaseLoginPage::class, false)) {
+        class_alias($filamentLoginPage, BaseLoginPage::class);
+    }
+
+    break;
+}
+
+if (! class_exists(BaseLoginPage::class, false)) {
+    throw new LogicException('A supported Filament login page could not be found.');
+}

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -1,5 +1,33 @@
 <?php
 
-it('will not use debugging functions')
-    ->expect(['dd', 'dump', 'ray'])
-    ->each->not->toBeUsed();
+namespace BetterFuturesStudio\FilamentLocalLogins\Tests;
+
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+final class ArchTest extends TestCase
+{
+    public function test_source_files_do_not_use_debugging_functions(): void
+    {
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(dirname(__DIR__).'/src'),
+        );
+
+        foreach ($files as $file) {
+            if (! $file instanceof SplFileInfo || ! $file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $contents = file_get_contents($file->getPathname());
+
+            self::assertIsString($contents);
+            self::assertDoesNotMatchRegularExpression(
+                '/\\b(?:dd|dump|ray)\\s*\\(/',
+                $contents,
+                "Debugging function found in {$file->getPathname()}",
+            );
+        }
+    }
+}

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-it('can test', function () {
-    expect(true)->toBeTrue();
-});

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace BetterFuturesStudio\FilamentLocalLogins\Tests\Fixtures;
+
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Panel;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class User extends Authenticatable implements FilamentUser
+{
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'email',
+        'password',
+        'can_access_panel',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'can_access_panel' => 'boolean',
+    ];
+
+    public function canAccessPanel(Panel $panel): bool
+    {
+        return $this->can_access_panel;
+    }
+}

--- a/tests/LocalLoginsTest.php
+++ b/tests/LocalLoginsTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace BetterFuturesStudio\FilamentLocalLogins\Tests;
+
+use BetterFuturesStudio\FilamentLocalLogins\Concerns\HasLocalLogins;
+use BetterFuturesStudio\FilamentLocalLogins\Filament\Pages\Auth\LoginPage;
+use BetterFuturesStudio\FilamentLocalLogins\LocalLogins;
+use BetterFuturesStudio\FilamentLocalLogins\Tests\Fixtures\User;
+use Filament\Facades\Filament;
+use Filament\Panel;
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class TestLoginPage
+{
+    use HasLocalLogins;
+
+    protected function throwFailureValidationException(): never
+    {
+        throw ValidationException::withMessages([
+            'data.email' => 'These credentials do not match our records.',
+        ]);
+    }
+}
+
+final class TestLoginResponse implements Responsable
+{
+    public function toResponse($request)
+    {
+        return response()->noContent();
+    }
+}
+
+final class LocalLoginsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->enableLocalLogins();
+        $this->bindLoginResponse();
+    }
+
+    public function test_it_extends_the_login_page_used_by_the_installed_filament_version(): void
+    {
+        $filamentLoginPage = class_exists('Filament\\Auth\\Pages\\Login')
+            ? 'Filament\\Auth\\Pages\\Login'
+            : 'Filament\\Pages\\Auth\\Login';
+
+        self::assertTrue(is_subclass_of(LoginPage::class, $filamentLoginPage));
+    }
+
+    public function test_it_registers_the_configured_login_page_when_enabled(): void
+    {
+        $panel = $this->makePanel();
+
+        self::assertSame(LoginPage::class, $panel->getLoginRouteAction());
+        self::assertTrue($panel->hasPlugin(LocalLogins::class));
+    }
+
+    public function test_it_does_not_replace_the_login_page_when_disabled(): void
+    {
+        config()->set('filament-local-logins.panels.admin.enabled', false);
+
+        $panel = $this->makePanel();
+
+        self::assertNull($panel->getLoginRouteAction());
+    }
+
+    public function test_it_normalizes_configured_email_addresses(): void
+    {
+        $this->enableLocalLogins([
+            ' developer@example.com ',
+            'developer@example.com',
+            '',
+            null,
+            'second@example.com',
+        ]);
+
+        self::assertSame([
+            'developer@example.com',
+            'second@example.com',
+        ], LocalLogins::make()->getEmails('admin'));
+    }
+
+    public function test_it_returns_no_accounts_when_the_plugin_is_not_registered(): void
+    {
+        $this->makePanel(registerPlugin: false);
+
+        self::assertSame([], (new TestLoginPage)->localLoginEmails());
+    }
+
+    public function test_it_returns_only_configured_accounts_for_an_enabled_panel(): void
+    {
+        $this->enableLocalLogins(['first@example.com', 'second@example.com']);
+        $this->makePanel();
+
+        self::assertSame([
+            'first@example.com',
+            'second@example.com',
+        ], (new TestLoginPage)->localLoginEmails());
+    }
+
+    public function test_it_rejects_an_account_that_is_not_configured_for_local_login(): void
+    {
+        User::query()->create([
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+        ]);
+        $this->makePanel();
+
+        try {
+            (new TestLoginPage)->loginUser('admin@example.com');
+            self::fail('An unconfigured account was allowed to log in.');
+        } catch (HttpException $exception) {
+            self::assertSame(403, $exception->getStatusCode());
+            self::assertSame('This account is not configured for local login.', $exception->getMessage());
+        }
+    }
+
+    public function test_it_rejects_a_configured_account_that_cannot_access_the_panel(): void
+    {
+        User::query()->create([
+            'email' => 'developer@example.com',
+            'password' => bcrypt('password'),
+            'can_access_panel' => false,
+        ]);
+        $this->makePanel();
+
+        try {
+            (new TestLoginPage)->loginUser('developer@example.com');
+            self::fail('A user without panel access was allowed to log in.');
+        } catch (ValidationException) {
+            self::assertFalse(auth('web')->check());
+        }
+    }
+
+    public function test_it_logs_in_a_configured_account_that_can_access_the_panel(): void
+    {
+        $user = User::query()->create([
+            'email' => 'developer@example.com',
+            'password' => bcrypt('password'),
+        ]);
+        $this->makePanel();
+
+        $response = (new TestLoginPage)->loginUser('developer@example.com');
+
+        self::assertInstanceOf(TestLoginResponse::class, $response);
+        self::assertSame($user->getKey(), auth('web')->id());
+    }
+
+    private function makePanel(bool $registerPlugin = true): Panel
+    {
+        $panel = Panel::make()
+            ->id('admin')
+            ->authGuard('web');
+
+        if ($registerPlugin) {
+            $panel->plugin(LocalLogins::make());
+        }
+
+        Filament::setCurrentPanel($panel);
+
+        return $panel;
+    }
+
+    /**
+     * @param  array<mixed>  $emails
+     */
+    private function enableLocalLogins(array $emails = ['developer@example.com']): void
+    {
+        config()->set('filament-local-logins.panels.admin', [
+            'enabled' => true,
+            'emails' => $emails,
+            'login_page' => LoginPage::class,
+        ]);
+    }
+
+    private function bindLoginResponse(): void
+    {
+        $contract = interface_exists('Filament\\Auth\\Http\\Responses\\Contracts\\LoginResponse')
+            ? 'Filament\\Auth\\Http\\Responses\\Contracts\\LoginResponse'
+            : 'Filament\\Http\\Responses\\Auth\\Contracts\\LoginResponse';
+
+        app()->bind($contract, fn (): TestLoginResponse => new TestLoginResponse);
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,0 @@
-<?php
-
-use BetterFuturesStudio\FilamentLocalLogins\Tests\TestCase;
-
-uses(TestCase::class)->in(__DIR__);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,11 @@
 namespace BetterFuturesStudio\FilamentLocalLogins\Tests;
 
 use BetterFuturesStudio\FilamentLocalLogins\FilamentLocalLoginsServiceProvider;
-use Illuminate\Database\Eloquent\Factories\Factory;
+use BetterFuturesStudio\FilamentLocalLogins\Tests\Fixtures\User;
+use Filament\FilamentServiceProvider;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
@@ -12,14 +16,21 @@ class TestCase extends Orchestra
     {
         parent::setUp();
 
-        Factory::guessFactoryNamesUsing(
-            fn (string $modelName) => 'BetterFuturesStudio\\FilamentLocalLogins\\Database\\Factories\\'.class_basename($modelName).'Factory'
-        );
+        Schema::create('users', function (Blueprint $table): void {
+            $table->id();
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->boolean('can_access_panel')->default(true);
+            $table->rememberToken();
+            $table->timestamps();
+        });
     }
 
     protected function getPackageProviders($app)
     {
         return [
+            LivewireServiceProvider::class,
+            FilamentServiceProvider::class,
             FilamentLocalLoginsServiceProvider::class,
         ];
     }
@@ -27,10 +38,19 @@ class TestCase extends Orchestra
     public function getEnvironmentSetUp($app)
     {
         config()->set('database.default', 'testing');
-
-        /*
-        $migration = include __DIR__.'/../database/migrations/create_filament-local-logins_table.php.stub';
-        $migration->up();
-        */
+        config()->set('database.connections.testing', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+        config()->set('auth.defaults.guard', 'web');
+        config()->set('auth.guards.web', [
+            'driver' => 'session',
+            'provider' => 'users',
+        ]);
+        config()->set('auth.providers.users', [
+            'driver' => 'eloquent',
+            'model' => User::class,
+        ]);
     }
 }


### PR DESCRIPTION
## Summary

- keep the package on the V1 line while supporting Filament 3, 4, and 5
- support Livewire 3 and 4, Laravel 10 through 13, and PHP 8.1 through 8.5
- bridge the Filament login-page and login-response namespace changes without breaking the public LoginPage class
- restrict local-login actions to configured panel accounts and preserve Filament panel-access checks
- normalize configured emails and safely encode Livewire action arguments
- replace the obsolete Pest 2 setup with a PHPUnit 10–13 behavioral suite
- expand CI to cover nine representative dependency combinations and refresh GitHub Actions
- document the compatibility matrix and restore the missing 1.4.0 changelog entry

## Local verification

- PHP 8.1 / Laravel 10 / Filament 3 / Livewire 3 / PHPUnit 10
- PHP 8.3 / Laravel 12 / Filament 4 / Livewire 3 / PHPUnit 12
- PHP 8.5 / Laravel 13 / Filament 5 / Livewire 4 / PHPUnit 13
- PHPStan
- Laravel Pint
- Composer validate
- Composer security audit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compatibility with Filament 3–5 and Laravel 10–13.
  * Improved local-login account validation, panel access checks, and login responses.
  * Login buttons now prevent duplicate submissions and safely handle email values.

* **Documentation**
  * Added compatibility guidance, security warnings, Composer instructions, and panel-specific login requirements.
  * Documented the 1.4.0 release and Laravel 12 support.

* **Bug Fixes**
  * Improved compatibility across supported Filament versions.
  * Normalized and filtered configured local-login email addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->