### PR TITLE
Publish the 1.5.0 changelog

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -25,8 +25,14 @@ jobs:
           release-notes: ${{ github.event.release.body }}
 
       - name: Commit updated CHANGELOG
+        id: auto-commit
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          branch: main
-          commit_message: Update CHANGELOG
+          branch: changelog/${{ github.event.release.tag_name }}
+          create_branch: true
+          commit_message: Update CHANGELOG for ${{ github.event.release.tag_name }}
           file_pattern: CHANGELOG.md
+
+      - name: Add pull request instructions
+        if: steps.auto-commit.outputs.changes_detected == 'true'
+        run: echo "Open a pull request from \`changelog/${{ github.event.release.tag_name }}\` into \`main\` to publish the generated changelog entry." >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to `filament-local-logins` will be documented in this file.
 
+## 1.5.0 - 2026-08-10
+
+### Compatibility
+
+- Add Filament 4 and 5 support while retaining Filament 3 compatibility.
+- Add Livewire 4 and Laravel 13 support while retaining Livewire 3 and Laravel 10–12 compatibility.
+- Support PHP 8.1–8.5, subject to the installed Laravel and Filament versions.
+- Bridge the authentication page and response namespaces moved by Filament 4 while preserving the package's existing `LoginPage` API.
+
+### Security and reliability
+
+- Accept local-login actions only for email addresses configured for the current panel.
+- Continue enforcing Filament's `canAccessPanel()` authorization check.
+- Normalize configured email addresses and safely encode Livewire action arguments.
+- Return no local accounts when the plugin is missing or disabled instead of throwing an exception.
+
+### Tests and maintenance
+
+- Replace the obsolete Pest 2 setup with a behavioral PHPUnit 10–13 test suite.
+- Test nine representative combinations across Filament 3–5, Livewire 3–4, Laravel 10–13, PHP 8.1–8.5, Linux, and Windows.
+- Update the GitHub Actions toolchain and merge the revalidated Dependabot pull requests [#21](https://github.com/better-futures-studio/filament-local-logins/pull/21), [#23](https://github.com/better-futures-studio/filament-local-logins/pull/23), [#24](https://github.com/better-futures-studio/filament-local-logins/pull/24), and [#25](https://github.com/better-futures-studio/filament-local-logins/pull/25).
+
+**Full Changelog**: https://github.com/better-futures-studio/filament-local-logins/compare/1.4.0...1.5.0
+
 ## 1.4.0 - 2025-05-05
 
 Add Laravel 12 support.


### PR DESCRIPTION
Publishes the final 1.5.0 release notes in the repository and changes the release workflow to push future generated changelogs to a dedicated branch, since protected `main` correctly rejects direct workflow commits.

Release: https://github.com/better-futures-studio/filament-local-logins/releases/tag/1.5.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 1.5.0, including compatibility updates, authentication improvements, local-login behavior, testing, CI, and maintenance changes.

* **Chores**
  * Updated changelog automation to prepare release-specific branches and provide pull request instructions when changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->